### PR TITLE
Fix Groovemarklet on strict Content-Type websites.

### DIFF
--- a/groovemarklet.html
+++ b/groovemarklet.html
@@ -18,7 +18,7 @@
             <br>
             Then, on your favorite online music site you click on the Groovemarklet, and SMG will do the rest.</p>
         </section>
-            <a href='javascript:(function(){document.body.appendChild(document.createElement("script")).src="//raw.github.com/Azeirah/azeirah.github.io/master/groovemarklet2.js"})()' class="groovemarklet">
+            <a href='javascript:(function(){document.body.appendChild(document.createElement("script")).src="//cdn.rawgit.com/Azeirah/azeirah.github.io/master/groovemarklet2.js"})()' class="groovemarklet">
             <button class="btn-lg btn-success">Groovemarklet</button>
         </a>
     </div>


### PR DESCRIPTION
Use rawgit as CDN which sets the right content-type, this will fix the Groovemarklet for plug.dj (and possibly for other sites)