### PR TITLE
Separate artist and song title for grooveshark

### DIFF
--- a/groovemarklet2dev.js
+++ b/groovemarklet2dev.js
@@ -8,7 +8,7 @@
       identifier,
       
       grooveshark = function () {
-        var song = $("#now-playing-metadata").text(),
+        var song =$("#now-playing-metadata .artist").text() + " - " + $("#now-playing-metadata .song").text(),
             title = "Grooveshark - " + song;
         return {
             song: song,


### PR DESCRIPTION
Hi,

On grooveshark, taking the text() of the now playing metadata would have the artist and the song title run together without any separator. I have updated the script so it fetches them separately and concatenates them with a " - ".

NOTE: I didn't update the minified version, let me know if you want me to do it (I'm going to assume you want to review the changes and do it yourself - just in case ;))

BTW, your script is greatly appreciated!

Zaki